### PR TITLE
fixes required for VS2022 compile

### DIFF
--- a/include/pl/hook.hpp
+++ b/include/pl/hook.hpp
@@ -33,7 +33,7 @@ namespace Pl {
     /// </summary>
     class HookBase {
     public:
-        HookBase::HookBase(std::byte* target, std::byte* hook)
+        HookBase(std::byte* target, std::byte* hook)
             : target(target), hook(hook) {
         }
 
@@ -115,7 +115,7 @@ namespace Pl {
     /// </summary>
     class HbpHook : public HookBase {
     public:
-        HbpHook::HbpHook(std::byte* target, std::byte* hook, bool enabled = true)
+        HbpHook(std::byte* target, std::byte* hook, bool enabled = true)
             : HookBase(target, hook) {
             if (enabled) {
                 Enable(true);


### PR DESCRIPTION
perfect-loader\include\pl/hook.hpp(36): error C4596: '{ctor}': illegal qualified name in member declaration
perfect-loader\include\pl/hook.hpp(118): error C3254: 'Pl::HbpHook': class contains explicit override '{ctor}' but does not derive from an interface that contains the function declaration
perfect-loader\include\pl/hook.hpp(118): error C3241: 'Pl::HbpHook::HbpHook(std::byte *,std::byte *,bool)': this method was not introduced by 'Pl::HookBase'
perfect-loader\include\pl/hook.hpp(118): note: see declaration of 'Pl::HbpHook::HbpHook'