### PR TITLE
source/loader.cpp - resolve PSIZE_T conversion error in VS 2022

### DIFF
--- a/source/loader.cpp
+++ b/source/loader.cpp
@@ -68,7 +68,8 @@ namespace Pl {
         if (useHbp) {
             PL_LAZY_LOAD_NATIVE_PROC(RtlSetProtectedPolicy);
             if (LazyRtlSetProtectedPolicy) {
-                (void)LazyRtlSetProtectedPolicy(&__uuidof(RtlpAddVectoredHandler), 0, &addVectoredHandlerProtectionPolicy);
+                SIZE_T propol(addVectoredHandlerProtectionPolicy) ;
+                (void)LazyRtlSetProtectedPolicy(&__uuidof(RtlpAddVectoredHandler), 0, &propol);
             }
         }
         if (flags & LoadFlags::UseTxf) {


### PR DESCRIPTION
loader.cpp(71): error C2664: 'NTSTATUS (const GUID *,SIZE_T,PSIZE_T)': cannot convert argument 3 from 'size_t *' to 'PSIZE_T'